### PR TITLE
make_ext4fs: add command-line -u option for UUID

### DIFF
--- a/ext4_sb.c
+++ b/ext4_sb.c
@@ -15,6 +15,7 @@
  */
 
 #include <errno.h>
+#include <string.h>
 
 #include "ext4_sb.h"
 
@@ -38,6 +39,7 @@ int ext4_parse_sb(struct ext4_super_block *sb, struct fs_info *info)
 	info->feat_incompat = sb->s_feature_incompat;
 	info->bg_desc_reserve_blocks = sb->s_reserved_gdt_blocks;
 	info->label = sb->s_volume_name;
+	memcpy(info->uuid, sb->s_uuid, 16);
 
 	len_blocks = ((uint64_t)sb->s_blocks_count_hi << 32) +
                 sb->s_blocks_count_lo;

--- a/ext4_sb.h
+++ b/ext4_sb.h
@@ -42,6 +42,7 @@ struct fs_info {
 	uint32_t reserve_pcnt;
 	const char *label;
 	uint8_t no_journal;
+	uint8_t uuid[16];
 };
 
 int ext4_parse_sb(struct ext4_super_block *sb, struct fs_info *info);

--- a/ext4_utils.h
+++ b/ext4_utils.h
@@ -113,6 +113,7 @@ struct fs_aux_info {
 extern struct fs_info info;
 extern struct fs_aux_info aux_info;
 extern struct sparse_file *ext4_sparse_file;
+extern int uuid_user_specified;
 
 extern jmp_buf setjmp_env;
 
@@ -145,6 +146,8 @@ u64 get_file_size(int fd);
 u64 parse_num(const char *arg);
 void ext4_parse_sb_info(struct ext4_super_block *sb);
 u16 ext4_crc16(u16 crc_in, const void *buf, int size);
+uint8_t *parse_uuid(uint8_t bytes[16], const char *str, size_t len);
+char *uuid_bin_to_str(char *buf, size_t buf_size, const uint8_t bytes[16]);
 
 typedef int (*fs_config_func_t)(const char *path, int dir, unsigned *uid, unsigned *gid,
 		unsigned *mode, uint64_t *capabilities);

--- a/make_ext4fs.c
+++ b/make_ext4fs.c
@@ -384,6 +384,7 @@ int make_ext4fs_internal(int fd, const char *_directory,
 	u32 root_inode_num;
 	u16 root_mode;
 	char *directory = NULL;
+	char buf[40];
 
 	if (setjmp(setjmp_env))
 		return EXIT_FAILURE; /* Handle a call to longjmp() */
@@ -443,6 +444,10 @@ int make_ext4fs_internal(int fd, const char *_directory,
 
 	info.bg_desc_reserve_blocks = compute_bg_desc_reserve_blocks();
 
+	if (!uuid_user_specified) {
+		generate_uuid("extandroid/make_ext4fs", info.label, info.uuid);
+	}
+
 	printf("Creating filesystem with parameters:\n");
 	printf("    Size: %"PRIu64"\n", info.len);
 	printf("    Block size: %d\n", info.block_size);
@@ -451,6 +456,7 @@ int make_ext4fs_internal(int fd, const char *_directory,
 	printf("    Inode size: %d\n", info.inode_size);
 	printf("    Journal blocks: %d\n", info.journal_blocks);
 	printf("    Label: %s\n", info.label);
+	printf("    UUID: %s\n", uuid_bin_to_str(buf, sizeof(buf), info.uuid));
 
 	ext4_create_fs_aux_info();
 

--- a/make_ext4fs_main.c
+++ b/make_ext4fs_main.c
@@ -29,13 +29,14 @@
 #include "canned_fs_config.h"
 
 extern struct fs_info info;
+extern int uuid_user_specified;
 
 
 static void usage(char *path)
 {
 	fprintf(stderr, "%s [ -l <len> ] [ -j <journal size> ] [ -b <block_size> ]\n", basename(path));
 	fprintf(stderr, "    [ -g <blocks per group> ] [ -i <inodes> ] [ -I <inode size> ]\n");
-	fprintf(stderr, "    [ -m <reserved blocks percent> ] [ -L <label> ] [ -f ]\n");
+	fprintf(stderr, "    [ -m <reserved blocks percent> ] [ -L <label> ] [ -u <uuid>] [ -f ]\n");
 	fprintf(stderr, "    [ -S file_contexts ] [ -C fs_config ] [ -T timestamp ]\n");
 	fprintf(stderr, "    [ -z | -s ] [ -w ] [ -c ] [ -J ] [ -v ] [ -B <block_list_file> ]\n");
 	fprintf(stderr, "    <filename> [<directory>]\n");
@@ -58,7 +59,7 @@ int main(int argc, char **argv)
 	time_t fixed_time = -1;
 	FILE* block_list_file = NULL;
 
-	while ((opt = getopt(argc, argv, "l:j:b:g:i:I:L:T:C:B:m:fwzJsctv")) != -1) {
+	while ((opt = getopt(argc, argv, "l:j:b:g:i:I:L:u:T:C:B:m:fwzJsctv")) != -1) {
 		switch (opt) {
 		case 'l':
 			info.len = parse_num(optarg);
@@ -80,6 +81,14 @@ int main(int argc, char **argv)
 			break;
 		case 'L':
 			info.label = optarg;
+			break;
+		case 'u':
+			if (!parse_uuid(info.uuid, optarg, strlen(optarg))) {
+				fprintf(stderr, "failed to parse UUID: '%s'\n",
+					optarg);
+				exit(EXIT_FAILURE);
+			}
+			uuid_user_specified = 1;
 			break;
 		case 'f':
 			force = 1;


### PR DESCRIPTION
As the ability to easily determine or specify the UUID of the file-system eases working with some bootloaders, this patch adds printing of the UUID upon file system creation with the other information and allows for the UUID to be specified as a command-line parameter.

Whether specified or automatically generated, the UUID is now printed with the Label and other creation information.

The parsing of command-line supplied UUIDs is relatively forgiving, allowing dash-separated values or not.

The default UUID generation remains unchanged as the hash of the file-system label.

fixes #1