### PR TITLE
fix LDFLAGS usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ OBJ := \
 	$(CC) $(CFLAGS) -c -o $@ $^
 
 make_ext4fs: $(OBJ) libsparse/libsparse.a
-	$(CC) $(LDFLAGS)-o $@ $^ $(ZLIB)
+	$(CC) $(LDFLAGS) -o $@ $^ $(ZLIB)
 
 libsparse/libsparse.a:
 	$(MAKE) -C libsparse/ libsparse.a


### PR DESCRIPTION
If LDFLAGS is non-empty then next standing "-o" flag may be mistakenly appended to it leading to build error.

fixes: 5c201be7d72a ("Add LDFLAGS when building libsparse.a")